### PR TITLE
Python 3 support for kairos

### DIFF
--- a/kairos/cassandra_backend.py
+++ b/kairos/cassandra_backend.py
@@ -14,25 +14,17 @@ from datetime import time as time_type
 from decimal import Decimal
 import re
 
+import six
 from six.moves.queue import Queue, Empty, Full
 from six.moves.urllib.parse import urlparse
 
-# Test python3 compatibility
-try:
-  x = long(1)
-except NameError:
-  long = int
-try:
-  x = unicode('foo')
-except NameError:
-  unicode = str
 
 TYPE_MAP = {
   str         : 'ascii',
   'str'       : 'ascii',
   'string'    : 'ascii',
 
-  unicode     : 'text',  # works for py3 too
+  six.text_type     : 'text',  # works for py3 too
   'unicode'   : 'text',
 
   float       : 'float',
@@ -44,7 +36,6 @@ TYPE_MAP = {
   'int'       : 'int',
   'integer'   : 'int',
 
-  long        : 'varint', # works for py3 too
   'long'      : 'varint',
   'int64'     : 'bigint',
 
@@ -60,6 +51,9 @@ TYPE_MAP = {
 
   'inet'      : 'inet',
 }
+if six.PY3:
+  long = int
+TYPE_MAP[long] = 'varint'
 
 QUOTE_TYPES = set(['ascii','text','blob'])
 QUOTE_MATCH = re.compile("^'.*'$")

--- a/kairos/cassandra_backend.py
+++ b/kairos/cassandra_backend.py
@@ -12,9 +12,10 @@ import time
 from datetime import date, datetime
 from datetime import time as time_type
 from decimal import Decimal
-from Queue import Queue, Empty, Full
 import re
-from urlparse import *
+
+from six.moves.queue import Queue, Empty, Full
+from six.moves.urllib.parse import urlparse
 
 # Test python3 compatibility
 try:

--- a/kairos/mongo_backend.py
+++ b/kairos/mongo_backend.py
@@ -134,9 +134,9 @@ class MongoBackend(Timeseries):
     updates = {}
     # TODO support flush interval
     for interval,config in self._intervals.items():
-      for timestamp,names in inserts.iteritems():
+      for timestamp,names in six.iteritems(inserts):
         timestamps = self._normalize_timestamps(timestamp, intervals, config)
-        for name,values in names.iteritems():
+        for name,values in six.iteritems(names):
           for value in values:
             for tstamp in timestamps:
               query,insert = self._insert_data(
@@ -313,7 +313,7 @@ class MongoHistogram(MongoBackend, Histogram):
     if not existing:
       return insert
 
-    for value,incr in insert['$inc'].iteritems():
+    for value,incr in six.iteritems(insert['$inc']):
       existing['$inc'][value] = existing['$inc'].get(value,0)+incr
     return existing
 

--- a/kairos/mongo_backend.py
+++ b/kairos/mongo_backend.py
@@ -13,7 +13,9 @@ import re
 import pymongo
 from pymongo import ASCENDING, DESCENDING
 from datetime import datetime
-from urlparse import *
+
+from six.moves.urllib.parse import urlparse
+
 
 class MongoBackend(Timeseries):
   '''

--- a/kairos/mongo_backend.py
+++ b/kairos/mongo_backend.py
@@ -14,6 +14,7 @@ import pymongo
 from pymongo import ASCENDING, DESCENDING
 from datetime import datetime
 
+import six
 from six.moves.urllib.parse import urlparse
 
 
@@ -94,7 +95,7 @@ class MongoBackend(Timeseries):
     Recursively unescape values. Though slower, this doesn't require the user to
     know anything about the escaping when writing their own custom fetch functions.
     '''
-    if isinstance(value, (str,unicode)):
+    if isinstance(value, six.string_types):
       return value.replace(self._escape_character, '.')
     elif isinstance(value, dict):
       return { self._unescape(k) : self._unescape(v) for k,v in value.items() }
@@ -192,7 +193,7 @@ class MongoBackend(Timeseries):
 
     # need to hide the period of any values. best option seems to be to pick
     # a character that "no one" uses.
-    if isinstance(value, (str,unicode)):
+    if isinstance(value, six.string_types):
       value = value.replace('.', self._escape_character)
     elif isinstance(value, float):
       value = str(value).replace('.', self._escape_character)

--- a/kairos/redis_backend.py
+++ b/kairos/redis_backend.py
@@ -11,6 +11,7 @@ import sys
 import time
 import re
 
+import six
 from redis import Redis
 from six.moves.urllib.parse import urlparse
 
@@ -112,8 +113,8 @@ class RedisBackend(Timeseries):
       own_pipe = True
 
     ttl_batch = set()
-    for timestamp,names in inserts.iteritems():
-      for name,values in names.iteritems():
+    for timestamp,names in six.iteritems(inserts):
+      for name,values in six.iteritems(names):
         for value in values:
           # TODO: support config param to flush the pipe every X inserts
           self._insert( name, value, timestamp, intervals, ttl_batch=ttl_batch, **kwargs )
@@ -133,7 +134,7 @@ class RedisBackend(Timeseries):
     else:
       pipe = self._client.pipeline(transaction=False)
 
-    for interval,config in self._intervals.iteritems():
+    for interval,config in six.iteritems(self._intervals):
       timestamps = self._normalize_timestamps(timestamp, intervals, config)
       for tstamp in timestamps:
         self._insert_data(name, value, tstamp, interval, config, pipe,

--- a/kairos/redis_backend.py
+++ b/kairos/redis_backend.py
@@ -10,8 +10,10 @@ import operator
 import sys
 import time
 import re
-from urlparse import *
+
 from redis import Redis
+from six.moves.urllib.parse import urlparse
+
 
 class RedisBackend(Timeseries):
   '''

--- a/kairos/sql_backend.py
+++ b/kairos/sql_backend.py
@@ -14,7 +14,9 @@ import time
 from datetime import date, datetime
 from datetime import time as time_type
 from decimal import Decimal
-from urlparse import *
+
+from six.moves.urllib.parse import urlparse
+
 
 # Test python3 compatibility
 try:

--- a/kairos/sql_backend.py
+++ b/kairos/sql_backend.py
@@ -15,25 +15,16 @@ from datetime import date, datetime
 from datetime import time as time_type
 from decimal import Decimal
 
+import six
 from six.moves.urllib.parse import urlparse
 
-
-# Test python3 compatibility
-try:
-  x = long(1)
-except NameError:
-  long = int
-try:
-  x = unicode('foo')
-except NameError:
-  unicode = str
 
 TYPE_MAP = {
   str         : String,
   'str'       : String,
   'string'    : String,
 
-  unicode     : Unicode,  # works for py3 too
+  six.text_type : Unicode,  # works for py3 too
   'unicode'   : Unicode,
 
   float       : Float,
@@ -43,7 +34,6 @@ TYPE_MAP = {
   'int'       : Integer,
   'integer'   : Integer,
 
-  long        : BigInteger, # works for py3 too
   'long'      : BigInteger,
   'int64'     : BigInteger,
 
@@ -65,6 +55,11 @@ TYPE_MAP = {
   'clob'      : Text,
   'blob'      : LargeBinary,
 }
+
+if six.PY3:
+  long = int
+TYPE_MAP[long] = BigInteger
+
 
 class SqlBackend(Timeseries):
 

--- a/kairos/timeseries.py
+++ b/kairos/timeseries.py
@@ -18,7 +18,9 @@ if sys.version_info[:2] > (2, 6):
 else:
     from ordereddict import OrderedDict
 
+import six
 from monthdelta import MonthDelta
+
 
 BACKENDS = {}
 
@@ -35,11 +37,9 @@ SIMPLE_TIMES = {
 
 GREGORIAN_TIMES = set(['daily', 'weekly', 'monthly', 'yearly'])
 
-# Test python3 compatibility
-try:
-  x = long(1)
-except NameError:
+if six.PY3:
   long = int
+
 
 def _resolve_time(value):
   '''

--- a/kairos/timeseries.py
+++ b/kairos/timeseries.py
@@ -3,6 +3,8 @@ Copyright (c) 2012-2017, Agora Games, LLC All rights reserved.
 
 https://github.com/agoragames/kairos/blob/master/LICENSE.txt
 '''
+from __future__ import division
+
 from .exceptions import *
 
 from datetime import datetime, timedelta
@@ -88,7 +90,7 @@ class RelativeTime(object):
     '''
     Calculate the bucket from a timestamp, optionally including a step offset.
     '''
-    return int( timestamp / self._step ) + steps
+    return int( timestamp // self._step ) + steps
 
   def from_bucket(self, bucket):
     '''
@@ -251,7 +253,7 @@ class GregorianTime(object):
         # Convert to number of days
         day_diff = (self.from_bucket(ntime, native=True) - self.from_bucket(rtime, native=True)).days
         # Convert steps to number of days as well
-        step_diff = (steps*SIMPLE_TIMES[self._step[0]]) / SIMPLE_TIMES['d']
+        step_diff = (steps*SIMPLE_TIMES[self._step[0]]) // SIMPLE_TIMES['d']
 
         # The relative time is beyond our TTL cutoff
         if day_diff > step_diff:
@@ -806,7 +808,7 @@ class Series(Timeseries):
     if transform=='mean':
       total = sum( data )
       count = len( data )
-      data = float(total)/float(count) if count>0 else 0
+      data = total / float(count) if count>0 else 0
     elif transform=='count':
       data = len( data )
     elif transform=='min':

--- a/kairos/timeseries.py
+++ b/kairos/timeseries.py
@@ -434,8 +434,8 @@ class Timeseries(object):
     if None in inserts:
       inserts[ time.time() ] = inserts.pop(None)
     if self._write_func:
-      for timestamp,names in inserts.iteritems():
-        for name,values in names.iteritems():
+      for timestamp,names in six.iteritems(inserts):
+        for name,values in six.iteritems(names):
           names[name] = [ self._write_func(v) for v in values ]
     self._batch_insert(inserts, intervals, **kwargs)
 
@@ -479,8 +479,8 @@ class Timeseries(object):
     Support for batch insert. Default implementation is non-optimized and
     is a simple loop over values.
     '''
-    for timestamp,names in inserts.iteritems():
-      for name,values in names.iteritems():
+    for timestamp,names in six.iteritems(inserts):
+      for name,values in six.iteritems(names):
         for value in values:
           self._insert( name, value, timestamp, intervals, **kwargs )
 

--- a/kairos/timeseries.py
+++ b/kairos/timeseries.py
@@ -297,7 +297,7 @@ class Timeseries(object):
         return backend( client, **kwargs )
 
       raise ImportError("Unsupported or unknown client type %s", client_module)
-    return object.__new__(cls, client, **kwargs)
+    return object.__new__(cls)
 
   def __init__(self, client, **kwargs):
     '''

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,4 @@
 # For calculating month deltas in gregorian systems
 MonthDelta==1.0b
+# Python 2/3 compatibility
+six==1.11.0

--- a/test/unit/cassandra_timeseries_test.py
+++ b/test/unit/cassandra_timeseries_test.py
@@ -1,7 +1,7 @@
 '''
 Functional tests for cassandra timeseries
 '''
-from Queue import Queue, Empty, Full
+from six.moves.queue import Queue, Empty, Full
 
 import cql
 from chai import Chai


### PR DESCRIPTION
I was trying to convert Prometheus code to Python 3, but then I noticed that kairos is our only dependency which actually does not work on Python 3 per se, even though they claim support for it. So I took for a spin and converted it to work in  a 2/3 compatible fashion. 
Do note that the kairos tests don't actually work, and don't want to spend time investigating these, since they are mostly related to Cassandra/cql, we don't care about that. ``prometheus`` tests pass with this fork.