### PR TITLE
Update version to valid PEP 440 identifier [AP-1980]

### DIFF
--- a/kairos/__init__.py
+++ b/kairos/__init__.py
@@ -4,7 +4,7 @@ Copyright (c) 2012-2017, Agora Games, LLC All rights reserved.
 https://github.com/agoragames/kairos/blob/master/LICENSE.txt
 '''
 from __future__ import absolute_import
-__version__ = "0.10.1.zapier"
+__version__ = "0.10.1.post1"
 
 from .timeseries import Timeseries
 from .exceptions import *


### PR DESCRIPTION
Poetry 1.3 now rejects invalid identifies. `*.zapier` does not comply with PEP 440.

https://zapierorg.atlassian.net/browse/AP-1980